### PR TITLE
Add xilinx to accelerator_model_name

### DIFF
--- a/open/DellEMC/systems/R740xd_u280_v3me.json
+++ b/open/DellEMC/systems/R740xd_u280_v3me.json
@@ -12,7 +12,7 @@
   "host_storage_type": "HDD",
   "host_storage_capacity": "21.42 GB",
   "accelerators_per_node": 1,
-  "accelerator_model_name": "u280_v3me",
+  "accelerator_model_name": "xilinx_u280_v3me",
   "accelerator_memory_configuration": "HBM",
   "accelerator_memory_capacity": "16 GB per accelerator",
   "framework": "TF",

--- a/open/DellEMC/systems/R740xd_vck5000.json
+++ b/open/DellEMC/systems/R740xd_vck5000.json
@@ -12,7 +12,7 @@
   "host_storage_type": "HDD",
   "host_storage_capacity": "20 GB",
   "accelerators_per_node": 1,
-  "accelerator_model_name": "vck5000_v4e",
+  "accelerator_model_name": "xilinx_vck5000_v4e",
   "accelerator_memory_configuration": "DDR",
   "accelerator_memory_capacity": "16 GB per accelerator",
   "framework": "TF",


### PR DESCRIPTION
A small trivial change is requested here.

It may not be clear that vck5000_v4e is realized as a xilinx FPGA, so we would like to prepend the string "xilinx_".

Same story for the v3me submission.